### PR TITLE
kw_extractor skips images, audio,videos

### DIFF
--- a/python/src/kw_extractor.py
+++ b/python/src/kw_extractor.py
@@ -39,7 +39,16 @@ class KWExtractor:
     #open a file (check which type and send to be opened in the correct way)
     def open_file(self, file_name, file_type, max_duration_seconds=1):
         result = []
-        if file_type == "application/pdf":
+        if "image" in file_type:
+            #print("Image reading")
+            pass
+        elif "audio" in file_type:
+            #print("Audio reading")
+            pass
+        elif "video" in file_type:
+            #print("Video reading")
+            pass
+        elif file_type == "application/pdf":
             keywords = self.pdf_extraction(file_name, '.', max_duration_seconds)
             result.append((file_name, keywords))
         elif file_type in ["application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"]:

--- a/python/testing/test_clustering.py
+++ b/python/testing/test_clustering.py
@@ -63,7 +63,8 @@ def createDirectoryRequest():
         File(name="TODO mar30 Meeting.txt", original_path=get_path("TODO mar30 Meeting.txt")),
         File(name="Tututorial_2.pdf", original_path=get_path("Tututorial_2.pdf")),
         File(name="UseCase.png", original_path=get_path("UseCase.png")),
-        File(name="init.py", original_path=get_path("init.py"))
+        File(name="init.py", original_path=get_path("init.py")),
+        File(name="flamegraph.svg", original_path=get_path("flamegraph.svg"))
     ]
 
     root_dir = Directory(


### PR DESCRIPTION
# Hotfix
**Name**: _ Fixing kw_extractor not handling some types_
**Description**: _kw_extractor now skips over image, video, audio files_

**Tests Added**: _ test_clustering.py now includes image, svg, etc. _
**Coverage**: _Covers all cases in kw_cluster._
**Why**: _When clustering there are many different file types and if they aren't handled correctly the system crashes._
**Run**: _In root - ```make python_master_temp```_

