### PR TITLE
Go feature remove tag

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -166,14 +166,13 @@ Adds a tag to a specific file under a Smart Manager.
 
 **Parameters:**
 
-* `name`: Name of the Smart Manager.
 * `path`: Path to the file.
 * `tag`: Tag to assign.
 
 **Endpoint:**
 
 ```
-POST /addTag?name={name}&path={path}&tag={tag}
+POST /addTag?path={path}&tag={tag}
 ```
 
 **Returns:**
@@ -192,14 +191,13 @@ Removes a tag from a specific file.
 
 **Parameters:**
 
-* `name`: Name of the Smart Manager.
 * `path`: Path to the file.
 * `tag`: Tag to remove.
 
 **Endpoint:**
 
 ```
-POST /deleteTag?name={name}&path={path}&tag={tag}
+POST /removeTag?path={path}&tag={tag}
 ```
 
 **Returns:**

--- a/golang/filesystem/managedItem.go
+++ b/golang/filesystem/managedItem.go
@@ -149,7 +149,7 @@ func (f *Folder) RemoveTag(tag string) bool {
 // -------------------- File Methods --------------------
 func (f *File) Display(indent int) {
 	prefix := strings.Repeat("  ", indent)
-	fmt.Printf("%sFile: %s %s\n", prefix, f.Name, f.Path)
+	fmt.Printf("%sFile: %s\n", prefix, f.Name)
 
 	if len(f.Metadata) > 0 {
 		fmt.Printf("%s  Metadata:\n", prefix)

--- a/golang/filesystem/server.go
+++ b/golang/filesystem/server.go
@@ -117,7 +117,7 @@ func HandleRequests() {
 	http.HandleFunc("/removeDirectory", removeCompositeHandler)
 	http.HandleFunc("/addTag", addTagHandler)
 	http.HandleFunc("/removeTag", removeTagHandler)
-	// http.HandleFunc("/loadTreeData", loadTreeDataHandler)
+	http.HandleFunc("/loadTreeData", loadTreeDataHandler)
 	fmt.Println("Server started on port 51000")
 	// http.ListenAndServe(":51000", nil)
 	http.ListenAndServe("0.0.0.0:51000", nil)


### PR DESCRIPTION
Type: Feature
Summary 
Functionality to remove existing tags assigned to files or folders
Usage
Requires the path to the file and folder as well as the tag specified. Exact requirements as adding a tag.
Input -> output 
using the path: C:\\testdirectory\a.txt and the tag=High=priority in the request will assign the tag to that file in the composite


Tests for removing a tag (existing or not) from a file were already implemented in a previous PR and is still working.

Documentation:
API.md updated.
The previous docs on adding tags and removing tags were outdated as they showed that the name of the SM is needed.
I removed the wrong parameters and updated the /deleteTag endpoint to be /removeTag



