### PR TITLE
Go feature item locking

### DIFF
--- a/golang/filesystem/directoryToObject.go
+++ b/golang/filesystem/directoryToObject.go
@@ -24,6 +24,8 @@ func ConvertToObject(managerName, folderPath string) (*Folder, error) {
 		return nil, fmt.Errorf("error exploring folder %q: %w", cleanPath, err)
 	}
 
+	autoLockHiddenFolders(root)
+
 	return root, nil
 }
 
@@ -62,6 +64,19 @@ func exploreDown(folder *Folder, path string) error {
 		}
 	}
 	return nil
+}
+
+func autoLockHiddenFolders(folder *Folder) {
+	for _, sub := range folder.Subfolders {
+		autoLockHiddenFolders(sub)
+
+		// Check if subfolder is hidden
+		if strings.HasPrefix(sub.Name, ".") {
+			folder.Locked = true
+			fmt.Printf("Auto-locked folder '%s' because it contains hidden folder '%s'\n", folder.Path, sub.Name)
+			break // No need to check further
+		}
+	}
 }
 
 func ConvertToWSLPath(winPath string) string {

--- a/golang/filesystem/directoryToObject_test.go
+++ b/golang/filesystem/directoryToObject_test.go
@@ -2,17 +2,26 @@ package filesystem
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestConvertToObject(t *testing.T) {
-	// Define path to test root folder (adjust relative path as needed)
 	rootPath := "../../testRootFolder"
+	subdirPath := filepath.Join(rootPath, "subdir")
+	hiddenPath := filepath.Join(subdirPath, ".hiddenFolder")
 
-	// Ensure test directory exists
-	if info, err := os.Stat(rootPath); err != nil || !info.IsDir() {
-		t.Fatalf("Test directory %s does not exist or is not a directory", rootPath)
+	// Ensure testRootFolder/subdir exists
+	if info, err := os.Stat(subdirPath); err != nil || !info.IsDir() {
+		t.Fatalf("Expected subdir at %s, got error: %v", subdirPath, err)
 	}
+
+	// Create .hiddenFolder inside subdir for testing
+	err := os.MkdirAll(hiddenPath, 0755)
+	if err != nil && !os.IsExist(err) {
+		t.Fatalf("Failed to create hidden folder for test: %v", err)
+	}
+	defer os.RemoveAll(hiddenPath) // Cleanup after test
 
 	// Convert directory into Folder tree
 	root, err := ConvertToObject("TestRoot", rootPath)
@@ -25,25 +34,22 @@ func TestConvertToObject(t *testing.T) {
 		t.Error("Expected at least one file or subfolder in root, got none")
 	}
 
-	// Map of expected items
+	// Check top-level expected items
 	expected := map[string]struct{}{
 		"a.txt":  {},
 		"subdir": {},
 	}
-
-	// Check root files
 	for _, f := range root.Files {
 		if _, ok := expected[f.Name]; ok {
 			delete(expected, f.Name)
 		}
 	}
 
-	// Find 'subdir' folder and inspect its contents
 	for _, sf := range root.Subfolders {
 		if sf.Name == "subdir" {
-			// mark found
 			delete(expected, "subdir")
-			// look for nested items
+
+			// Check nested files
 			nestedExpected := map[string]struct{}{
 				"empty.txt":     {},
 				"metadata.webp": {},
@@ -53,16 +59,22 @@ func TestConvertToObject(t *testing.T) {
 					delete(nestedExpected, nf.Name)
 				}
 			}
-			// report missing in subdir
 			for name := range nestedExpected {
 				t.Errorf("Expected to find %s in subdir, but did not", name)
+			}
+
+			// 🔒 Verify subdir is auto-locked due to hidden folder
+			if !sf.Locked {
+				t.Errorf("Expected folder %q to be locked due to hidden folder, but it was not", sf.Name)
 			}
 		}
 	}
 
-	// Report missing in root
+	// Report missing top-level files/folders
 	for name := range expected {
 		t.Errorf("Expected to find %s in root, but did not", name)
 	}
+
+	// Optionally visualize
 	root.Display(0)
 }

--- a/golang/filesystem/server.go
+++ b/golang/filesystem/server.go
@@ -119,6 +119,19 @@ func lockHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("true"))
 }
 
+// Unlocks a file or folder and its children
+func unlockHandler(w http.ResponseWriter, r *http.Request) {
+	path := ConvertToWSLPath(r.URL.Query().Get("path"))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, c := range composites {
+		c.UnlockByPath(path)
+	}
+	w.Write([]byte("true"))
+}
+
 func HandleRequests() {
 
 	// path, _ := os.Getwd()
@@ -134,6 +147,7 @@ func HandleRequests() {
 	http.HandleFunc("/loadTreeData", loadTreeDataHandler)
 	http.HandleFunc("/sortTree", sortTreeHandler)
 	http.HandleFunc("/lock", lockHandler)
+	http.HandleFunc("/unlock", unlockHandler)
 
 	fmt.Println("Server started on port 51000")
 	// http.ListenAndServe(":51000", nil)

--- a/golang/filesystem/server.go
+++ b/golang/filesystem/server.go
@@ -106,6 +106,19 @@ func removeTagHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("false"))
 }
 
+// Locks a file or folder and its children
+func lockHandler(w http.ResponseWriter, r *http.Request) {
+	path := ConvertToWSLPath(r.URL.Query().Get("path"))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, c := range composites {
+		c.LockByPath(path)
+	}
+	w.Write([]byte("true"))
+}
+
 func HandleRequests() {
 
 	// path, _ := os.Getwd()
@@ -120,6 +133,8 @@ func HandleRequests() {
 	http.HandleFunc("/removeTag", removeTagHandler)
 	http.HandleFunc("/loadTreeData", loadTreeDataHandler)
 	http.HandleFunc("/sortTree", sortTreeHandler)
+	http.HandleFunc("/lock", lockHandler)
+
 	fmt.Println("Server started on port 51000")
 	// http.ListenAndServe(":51000", nil)
 	http.ListenAndServe("0.0.0.0:51000", nil)

--- a/golang/filesystem/server_test.go
+++ b/golang/filesystem/server_test.go
@@ -1,0 +1,22 @@
+package filesystem
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAPI_AddAndRemoveDirectory(t *testing.T) {
+	req := httptest.NewRequest("GET", "/addDirectory?name=testdir&path=./testdata", nil)
+	w := httptest.NewRecorder()
+	addCompositeHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("expected true, got %s", w.Body.String())
+	}
+
+	req = httptest.NewRequest("GET", "/removeDirectory?path=./testdata", nil)
+	w = httptest.NewRecorder()
+	removeCompositeHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("expected true, got %s", w.Body.String())
+	}
+}

--- a/golang/filesystem/server_test.go
+++ b/golang/filesystem/server_test.go
@@ -43,3 +43,31 @@ func TestAPI_AddAndRemoveTag(t *testing.T) {
 		t.Fatalf("removeTagHandler: expected true, got %s", w.Body.String())
 	}
 }
+
+func TestAPI_LockUnlock(t *testing.T) {
+	// Add composite
+	req := httptest.NewRequest("GET", "/addDirectory?name=testlock&path=./testRootFolder", nil)
+	w := httptest.NewRecorder()
+	addCompositeHandler(w, req)
+
+	// Lock
+	req = httptest.NewRequest("GET", "/lock?path=./testRootFolder", nil)
+	w = httptest.NewRecorder()
+	lockHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("lockHandler: expected true, got %s", w.Body.String())
+	}
+
+	// Unlock
+	req = httptest.NewRequest("GET", "/unlock?path=./testRootFolder", nil)
+	w = httptest.NewRecorder()
+	unlockHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("unlockHandler: expected true, got %s", w.Body.String())
+	}
+
+	// Cleanup
+	req = httptest.NewRequest("GET", "/removeDirectory?path=./testRootFolder", nil)
+	w = httptest.NewRecorder()
+	removeCompositeHandler(w, req)
+}

--- a/golang/filesystem/server_test.go
+++ b/golang/filesystem/server_test.go
@@ -46,12 +46,12 @@ func TestAPI_AddAndRemoveTag(t *testing.T) {
 
 func TestAPI_LockUnlock(t *testing.T) {
 	// Add composite
-	req := httptest.NewRequest("GET", "/addDirectory?name=testlock&path=./testRootFolder", nil)
+	req := httptest.NewRequest("GET", "/addDirectory?name=testlock&path=../../testRootFolder", nil)
 	w := httptest.NewRecorder()
 	addCompositeHandler(w, req)
 
 	// Lock
-	req = httptest.NewRequest("GET", "/lock?path=./testRootFolder", nil)
+	req = httptest.NewRequest("GET", "/lock?path=../../testRootFolder", nil)
 	w = httptest.NewRecorder()
 	lockHandler(w, req)
 	if w.Body.String() != "true" {
@@ -59,7 +59,7 @@ func TestAPI_LockUnlock(t *testing.T) {
 	}
 
 	// Unlock
-	req = httptest.NewRequest("GET", "/unlock?path=./testRootFolder", nil)
+	req = httptest.NewRequest("GET", "/unlock?path=../../testRootFolder", nil)
 	w = httptest.NewRecorder()
 	unlockHandler(w, req)
 	if w.Body.String() != "true" {
@@ -67,7 +67,25 @@ func TestAPI_LockUnlock(t *testing.T) {
 	}
 
 	// Cleanup
-	req = httptest.NewRequest("GET", "/removeDirectory?path=./testRootFolder", nil)
+	req = httptest.NewRequest("GET", "/removeDirectory?path=../t../estRootFolder", nil)
 	w = httptest.NewRecorder()
 	removeCompositeHandler(w, req)
+}
+
+func TestAPI_EndpointsInvalidCases(t *testing.T) {
+	// Try removing non-existent composite
+	req := httptest.NewRequest("GET", "/removeDirectory?path=./invalid", nil)
+	w := httptest.NewRecorder()
+	removeCompositeHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Errorf("expected true even for non-existent remove, got %s", w.Body.String())
+	}
+
+	// Add tag to nonexistent file
+	req = httptest.NewRequest("GET", "/addTag?path=./invalid/file.txt&tag=none", nil)
+	w = httptest.NewRecorder()
+	addTagHandler(w, req)
+	if w.Body.String() != "false" {
+		t.Errorf("expected false for non-existent file tag, got %s", w.Body.String())
+	}
 }

--- a/golang/filesystem/server_test.go
+++ b/golang/filesystem/server_test.go
@@ -6,17 +6,40 @@ import (
 )
 
 func TestAPI_AddAndRemoveDirectory(t *testing.T) {
-	req := httptest.NewRequest("GET", "/addDirectory?name=testdir&path=./testdata", nil)
+	req := httptest.NewRequest("GET", "/addDirectory?name=testdir&path=../../testRootFolder", nil)
 	w := httptest.NewRecorder()
 	addCompositeHandler(w, req)
 	if w.Body.String() != "true" {
 		t.Fatalf("expected true, got %s", w.Body.String())
 	}
 
-	req = httptest.NewRequest("GET", "/removeDirectory?path=./testdata", nil)
+	req = httptest.NewRequest("GET", "/removeDirectory?path=../../testRootFolder", nil)
 	w = httptest.NewRecorder()
 	removeCompositeHandler(w, req)
 	if w.Body.String() != "true" {
 		t.Fatalf("expected true, got %s", w.Body.String())
+	}
+}
+
+func TestAPI_AddAndRemoveTag(t *testing.T) {
+	// Add folder to operate on
+	req := httptest.NewRequest("GET", "/addDirectory?name=testdir&path=../../testRootFolder", nil)
+	w := httptest.NewRecorder()
+	addCompositeHandler(w, req)
+
+	// Tag a file inside the test folder
+	req = httptest.NewRequest("GET", "/addTag?path=../../testRootFolder/subdir/rb24.rs&tag=important", nil)
+	w = httptest.NewRecorder()
+	addTagHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("addTagHandler: expected true, got %s", w.Body.String())
+	}
+
+	// Remove the tag
+	req = httptest.NewRequest("GET", "/removeTag?path=../../testRootFolder/subdir/rb24.rs&tag=important", nil)
+	w = httptest.NewRecorder()
+	removeTagHandler(w, req)
+	if w.Body.String() != "true" {
+		t.Fatalf("removeTagHandler: expected true, got %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
### Summary
This pull request contains functionality for locking and unlocking of folders and files. It also contains an update for the directoryToObject functionality to automatically lock folders containing hidden folders to dependencies in user files. Endpoints for locking and unlocking have been implemented and are used as follows:

### Usage
Locking: 
/lock?path=../../testRootFolder"
Unlocking:
"/unlock?path=../../testRootFolder"

All objects (files/folders) have a parameter "locked" which is false by default. These functions lock the file and if a folder is locked all subfolders and subfiles are also locked.

This functionality allows users to ignore folders that they want untouched by the file sorter.

### Test addition
Tests were added to each of the following files in regards to locking
- managedItem_test.go
- DirectoryToObject_test.go
New test file added for testing the API and the following tests were added to that file
- adding and removing directories
- adding and removing tags
- locking and unlocking files
Test coverage at time of request
- directoryToObject: 79.4%
- managedItem: 90.5%
- Server: 71.4%

The following was used to test coverage:
cd golang/filesystem
go test -coverprofile=coverage.out ./...
go tool cover -html=coverage.out
