### PR TITLE
Go feature return duplicates

### DIFF
--- a/docs/documentation/demo_2/api.md
+++ b/docs/documentation/demo_2/api.md
@@ -377,9 +377,6 @@ Unlocks a file or folder. When unlocking a folder all sub-folders, -files are al
 * Make sure to URI-encode query parameter values when needed.
 * The backend must be running at the defined base URI for requests to succeed.
 
-Let me know if you'd like a PDF or markdown version of this.
-
-
 
 # startUp
 
@@ -396,3 +393,51 @@ get /startUp
     "first2"
   ]
 }
+
+---
+
+## findDuplicates
+
+Identifies and returns a list of files that are considered duplicates based on file size, hash, and content matching.
+
+**Parameters:**
+
+* `name`: The name of the Smart Manager to search for duplicates in.
+
+**Endpoint:**
+
+```
+GET /findDuplicates?name={name}
+```
+
+**Returns:**
+
+* A JSON array of duplicate file pairs. Each object includes:
+
+  * `name`: The common file name.
+  * `original`: The full path to the original file.
+  * `duplicate`: The full path to the detected duplicate.
+
+**Example Response:**
+
+```json
+[
+  {
+    "name": "The Man of Steel.docx",
+    "original": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/The Man of Steel (another copy).docx",
+    "duplicate": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/The Man of Steel.docx"
+  },
+  {
+    "name": "pyramid-technology.pdf",
+    "original": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/pyramid-technology (copy).pdf",
+    "duplicate": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/pyramid-technology.pdf"
+  }
+]
+```
+
+**Throws:**
+
+* Exception if the request fails or if the Smart Manager name is invalid.
+
+---
+

--- a/golang/filesystem/duplicateFiles.go
+++ b/golang/filesystem/duplicateFiles.go
@@ -2,110 +2,80 @@ package filesystem
 
 import (
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
-	"hash"
 	"io"
 	"log"
+	"net/http"
 	"os"
-	"path/filepath"
 )
 
-func FindDuplicateFiles(root *Folder) []*File {
-	// First pass
-	sizeBuckets := make(map[int64][]string)
-	collectBySize(root, sizeBuckets)
+type DuplicateEntry struct {
+	Name      string `json:"name"`
+	Original  string `json:"original"`
+	Duplicate string `json:"duplicate"`
+}
 
-	duplicates := []*File{}
+func computeFileHash(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		log.Printf("failed to open file %s: %v", path, err)
+		return ""
+	}
+	defer f.Close()
 
-	// Second pass
-	for _, paths := range sizeBuckets {
-		if len(paths) < 2 {
-			continue
-		}
+	h := md5.New()
+	_, err = io.Copy(h, f)
+	if err != nil {
+		log.Printf("failed to hash file %s: %v", path, err)
+		return ""
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
 
-		// 2a) sample-hash
-		sampleBuckets := make(map[string][]string)
-		for _, p := range paths {
-			sig, err := sampleHash(p)
-			if err != nil {
-				log.Printf("sampleHash error for %s: %v", p, err)
+func FindDuplicateFiles(item *Folder) []DuplicateEntry {
+	fileHashes := make(map[string]string)
+	var duplicates []DuplicateEntry
+
+	var walk func(folder *Folder)
+	walk = func(folder *Folder) {
+		for _, file := range folder.Files {
+			hash := computeFileHash(file.Path)
+			if hash == "" {
 				continue
 			}
-			sampleBuckets[sig] = append(sampleBuckets[sig], p)
+			if origPath, exists := fileHashes[hash]; exists {
+				duplicates = append(duplicates, DuplicateEntry{
+					Name:      file.Name,
+					Original:  origPath,
+					Duplicate: file.Path,
+				})
+			} else {
+				fileHashes[hash] = file.Path
+			}
 		}
-
-		// full-hash remaining groups
-		for _, group := range sampleBuckets {
-			if len(group) < 2 {
-				continue
-			}
-			fullMap := make(map[string]string)
-			for _, p := range group {
-				fh, err := fullHash(p)
-				if err != nil {
-					log.Printf("fullHash error for %s: %v", p, err)
-					continue
-				}
-				if existing, found := fullMap[fh]; found {
-					duplicates = append(duplicates, &File{
-						Name: filepath.Base(p),
-						Path: existing,
-					})
-				} else {
-					fullMap[fh] = p
-				}
-			}
+		for _, sub := range folder.Subfolders {
+			walk(sub)
 		}
 	}
 
+	walk(item)
 	return duplicates
 }
 
-// collectBySize recurses through Folder, grouping files by their file size.
-func collectBySize(item *Folder, buckets map[int64][]string) {
-	for _, f := range item.Files {
-		if info, err := os.Stat(f.Path); err == nil && info.Mode().IsRegular() {
-			buckets[info.Size()] = append(buckets[info.Size()], f.Path)
+func findDuplicateFilesHandler(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, c := range composites {
+		if c.Name == name {
+			duplicates := FindDuplicateFiles(c)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(duplicates)
+			return
 		}
 	}
-	for _, sf := range item.Subfolders {
-		collectBySize(sf, buckets)
-	}
-}
 
-// sampleHash reads up to the first 4KB of a file and returns an MD5 signature.
-func sampleHash(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	buf := make([]byte, 4096)
-	n, err := f.Read(buf)
-	if err != nil && err != io.EOF {
-		return "", err
-	}
-
-	h := md5.Sum(buf[:n])
-	return fmt.Sprintf("%x", h[:]), nil
-}
-
-// fullHash reads the entire file and returns its MD5 hash.
-func fullHash(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	return hashFile(md5.New(), f)
-}
-
-// hashFile streams data from r into the provided hash.Hash and returns the hex string.
-func hashFile(h hash.Hash, r io.Reader) (string, error) {
-	if _, err := io.Copy(h, r); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	http.Error(w, "composite not found", http.StatusNotFound)
 }

--- a/golang/filesystem/duplicateFiles.go
+++ b/golang/filesystem/duplicateFiles.go
@@ -1,0 +1,111 @@
+package filesystem
+
+import (
+	"crypto/md5"
+	"fmt"
+	"hash"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func FindDuplicateFiles(root *Folder) []*File {
+	// First pass
+	sizeBuckets := make(map[int64][]string)
+	collectBySize(root, sizeBuckets)
+
+	duplicates := []*File{}
+
+	// Second pass
+	for _, paths := range sizeBuckets {
+		if len(paths) < 2 {
+			continue
+		}
+
+		// 2a) sample-hash
+		sampleBuckets := make(map[string][]string)
+		for _, p := range paths {
+			sig, err := sampleHash(p)
+			if err != nil {
+				log.Printf("sampleHash error for %s: %v", p, err)
+				continue
+			}
+			sampleBuckets[sig] = append(sampleBuckets[sig], p)
+		}
+
+		// full-hash remaining groups
+		for _, group := range sampleBuckets {
+			if len(group) < 2 {
+				continue
+			}
+			fullMap := make(map[string]string)
+			for _, p := range group {
+				fh, err := fullHash(p)
+				if err != nil {
+					log.Printf("fullHash error for %s: %v", p, err)
+					continue
+				}
+				if existing, found := fullMap[fh]; found {
+					duplicates = append(duplicates, &File{
+						Name: filepath.Base(p),
+						Path: existing,
+					})
+				} else {
+					fullMap[fh] = p
+				}
+			}
+		}
+	}
+
+	return duplicates
+}
+
+// collectBySize recurses through Folder, grouping files by their file size.
+func collectBySize(item *Folder, buckets map[int64][]string) {
+	for _, f := range item.Files {
+		if info, err := os.Stat(f.Path); err == nil && info.Mode().IsRegular() {
+			buckets[info.Size()] = append(buckets[info.Size()], f.Path)
+		}
+	}
+	for _, sf := range item.Subfolders {
+		collectBySize(sf, buckets)
+	}
+}
+
+// sampleHash reads up to the first 4KB of a file and returns an MD5 signature.
+func sampleHash(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	buf := make([]byte, 4096)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	h := md5.Sum(buf[:n])
+	return fmt.Sprintf("%x", h[:]), nil
+}
+
+// fullHash reads the entire file and returns its MD5 hash.
+func fullHash(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	return hashFile(md5.New(), f)
+}
+
+// hashFile streams data from r into the provided hash.Hash and returns the hex string.
+func hashFile(h hash.Hash, r io.Reader) (string, error) {
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/golang/filesystem/dupliciteFiles_test.go
+++ b/golang/filesystem/dupliciteFiles_test.go
@@ -1,0 +1,97 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// Test simple duplicates in a single folder
+func TestFindDuplicateFiles_Simple(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create two files with identical content
+	pathA := filepath.Join(tmp, "fileA.txt")
+	pathB := filepath.Join(tmp, "fileB.txt")
+	content := []byte("duplicate content")
+	if err := os.WriteFile(pathA, content, 0644); err != nil {
+		t.Fatalf("failed to write file A: %v", err)
+	}
+	if err := os.WriteFile(pathB, content, 0644); err != nil {
+		t.Fatalf("failed to write file B: %v", err)
+	}
+
+	// Build Folder struct
+	folder := &Folder{
+		Files: []*File{
+			{Name: "fileA.txt", Path: pathA},
+			{Name: "fileB.txt", Path: pathB},
+		},
+	}
+
+	// Invoke duplicate finder
+	dups := FindDuplicateFiles(folder)
+
+	// Expect exactly one duplicate pair
+	if len(dups) != 1 {
+		t.Fatalf("expected 1 duplicate, got %d", len(dups))
+	}
+
+	exp := DuplicateEntry{
+		Name:      "fileB.txt",
+		Original:  pathA,
+		Duplicate: pathB,
+	}
+	if !reflect.DeepEqual(dups[0], exp) {
+		t.Errorf("unexpected duplicate entry: got  %+v want %+v", dups[0], exp)
+	}
+}
+
+// Test duplicates within nested subfolders
+func TestFindDuplicateFiles_Nested(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create a subfolder and two duplicate files inside
+	sub := filepath.Join(tmp, "subfolder")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatalf("failed to create subfolder: %v", err)
+	}
+	path1 := filepath.Join(sub, "a.txt")
+	path2 := filepath.Join(sub, "copy_of_a.txt")
+	content := []byte("nested duplicate")
+	if err := os.WriteFile(path1, content, 0644); err != nil {
+		t.Fatalf("failed to write path1: %v", err)
+	}
+	if err := os.WriteFile(path2, content, 0644); err != nil {
+		t.Fatalf("failed to write path2: %v", err)
+	}
+
+	// Build Folder struct with nested Folder
+	subFolder := &Folder{
+		Files: []*File{
+			{Name: "a.txt", Path: path1},
+			{Name: "copy_of_a.txt", Path: path2},
+		},
+	}
+	root := &Folder{
+		Subfolders: []*Folder{subFolder},
+	}
+
+	// Invoke duplicate finder
+	dups := FindDuplicateFiles(root)
+
+	// Expect exactly one duplicate pair
+	if len(dups) != 1 {
+		t.Fatalf("expected 1 duplicate in nested, got %d", len(dups))
+	}
+
+	exp := DuplicateEntry{
+		Name:      "copy_of_a.txt",
+		Original:  path1,
+		Duplicate: path2,
+	}
+	if !reflect.DeepEqual(dups[0], exp) {
+		t.Errorf("unexpected nested duplicate entry: got  %+v want %+v", dups[0], exp)
+	}
+}

--- a/golang/filesystem/server.go
+++ b/golang/filesystem/server.go
@@ -153,6 +153,7 @@ func HandleRequests() {
 	http.HandleFunc("/lock", lockHandler)
 	http.HandleFunc("/unlock", unlockHandler)
 	http.HandleFunc("/moveDirectory", moveDirectoryHandler)
+	http.HandleFunc("/findDuplicateFiles", findDuplicateFilesHandler)
 	fmt.Println("Server started on port 51000")
 	// http.ListenAndServe(":51000", nil)
 	http.ListenAndServe("0.0.0.0:51000", nil)


### PR DESCRIPTION
Summary
This pull request contains functionality for returning all duplicate files found in the smart manager. To make it more efficient I group files by size before hashing(which requires opening files and is thus slow). I also perform the first pass with only a partial hash to remove most files and for remaining files I do a full hash. 

Usage
Moving Directory:
"GET /findDuplicates?name={name}"

returns
* A JSON array of duplicate file pairs. Each object includes:

  * `name`: The common file name.
  * `original`: The full path to the original file.
  * `duplicate`: The full path to the detected duplicate.

**Example Response:**

```json
[
  {
    "name": "The Man of Steel.docx",
    "original": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/The Man of Steel (another copy).docx",
    "duplicate": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/The Man of Steel.docx"
  },
  {
    "name": "pyramid-technology.pdf",
    "original": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/pyramid-technology (copy).pdf",
    "duplicate": "/home/henco/Documents/University-Files/Third-year/COS-301/Papers2/pyramid-technology.pdf"
  }
]
```

Test addition
Tests were added to each of the following files in regards to finding duplicates

duplicateFiles_test.go
server_test.go
Test coverage at time of request
duplicteFiles: 82.9%
Server: 69.3%

The following was used to test coverage:
cd golang/filesystem
go test -coverprofile=coverage.out ./...
go tool cover -html=coverage.out