### PR TITLE
Go move files hot fix

### DIFF
--- a/golang/filesystem/moveDirectory.go
+++ b/golang/filesystem/moveDirectory.go
@@ -54,6 +54,7 @@ func moveContentRecursive(item *Folder) {
 		if err != nil {
 			panic(err)
 		}
+		file.Path = targetPath // Update the file's path to the new location
 
 	}
 	for _, subfolder := range item.Subfolders {

--- a/golang/filesystem/moveDirectory.go
+++ b/golang/filesystem/moveDirectory.go
@@ -54,9 +54,10 @@ func moveContentRecursive(item *Folder) {
 		if err != nil {
 			panic(err)
 		}
-		for _, subfolder := range item.Subfolders {
-			moveContentRecursive(subfolder)
-		}
+
+	}
+	for _, subfolder := range item.Subfolders {
+		moveContentRecursive(subfolder)
 	}
 }
 

--- a/golang/filesystem/moveDirectory.go
+++ b/golang/filesystem/moveDirectory.go
@@ -54,6 +54,9 @@ func moveContentRecursive(item *Folder) {
 		if err != nil {
 			panic(err)
 		}
+		for _, subfolder := range item.Subfolders {
+			moveContentRecursive(subfolder)
+		}
 	}
 }
 

--- a/python/src/k_means.py
+++ b/python/src/k_means.py
@@ -37,7 +37,7 @@ class KMeansCluster:
     
     def dirCluster(self,full_vecs,files):
         builder = DirectoryCreator(self.parent_folder,files) # instead of root it should be the parent folder
-        root_dir = self.recDirCluster(full_vecs, files, 0, self.folder_namer.generateFolderName(files), builder)
+        root_dir = self.recDirCluster(full_vecs, files, 0, self.parent_folder, builder)
         #print(root_dir)
         #self.printMetaData(root_dir)
         return root_dir


### PR DESCRIPTION
Summary:
Fixed errors regarding moving files over to a new directory

These changes include:
- Smart Manager name is no longer overwritten
- Files are actually moved over
- File paths are updated in object tree after moving

Tests were changed in the moveDirectory_test.go file to reflect the changes made.

No changes to documentation
