### PR TITLE
Go fix naming returns

### DIFF
--- a/golang/filesystem/moveDirectory.go
+++ b/golang/filesystem/moveDirectory.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -38,6 +39,50 @@ func moveContent(item *Folder) {
 	root = filepath.Join(root, "archives", item.Name)
 	moveContentRecursive(item)
 	//change root back to original path
+	item.Path = root
+	managersFilePath := getPath()
+	managersFilePath = filepath.Join(managersFilePath, "golang", "storage", "main.json")
+	//read storage
+	data, err := os.ReadFile(managersFilePath)
+	var exist bool
+	if os.IsNotExist(err) {
+		exist = false
+	}
+
+	var recs []ManagerRecord
+
+	//populates recs
+	if exist {
+		if err := json.Unmarshal(data, &recs); err != nil {
+			fmt.Println("error in unmarshaling of json")
+			panic(err)
+		}
+
+		for i := range recs {
+			if recs[i].Name == item.Name {
+				recs[i].Path = item.Path
+			}
+		}
+	} else {
+		if err := os.MkdirAll(filepath.Dir(managersFilePath), 0755); err != nil {
+			panic(err)
+		}
+		record := ManagerRecord{
+			item.Name,
+			item.Path,
+		}
+		recs = append(recs, record)
+	}
+
+	out, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	err = os.WriteFile(managersFilePath, out, 0644)
+	if err != nil {
+		panic(err)
+	}
+
 	os.Chdir("filesystem")
 }
 
@@ -88,6 +133,7 @@ func CreateDirectoryStructureRecursive(item *Folder) {
 	}
 }
 
+// helper functions
 func getPath() string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/golang/filesystem/server.go
+++ b/golang/filesystem/server.go
@@ -112,17 +112,25 @@ func removeTagHandler(w http.ResponseWriter, r *http.Request) {
 func lockHandler(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 	name := r.URL.Query().Get("name")
+	if path == "" || name == "" {
+		w.Write([]byte("Parameter missing"))
+		return
+	}
 	mu.Lock()
 	defer mu.Unlock()
 
 	for _, c := range composites {
 		if c.Name == name {
 			c.LockByPath(path)
+			fmt.Println("LOCKED FILE")
+			w.Write([]byte("true"))
+			return
 		} else {
 			w.Write([]byte("false"))
+			return
 		}
 	}
-	w.Write([]byte("true"))
+
 }
 
 // Unlocks a file or folder and its children
@@ -131,15 +139,21 @@ func unlockHandler(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")
 	mu.Lock()
 	defer mu.Unlock()
-
+	if path == "" || name == "" {
+		w.Write([]byte("Parameter missing"))
+		return
+	}
 	for _, c := range composites {
 		if c.Name == name {
 			c.UnlockByPath(path)
+			w.Write([]byte("true"))
+			return
 		} else {
 			w.Write([]byte("false"))
+			return
 		}
 	}
-	w.Write([]byte("true"))
+
 }
 
 func HandleRequests() {


### PR DESCRIPTION
Summary:
Fixed the storage of the new path after moving smartmanager to new directory.
Fixed lock endpoint, no longer returns "falsetrue" upon successful call.

All tests still pass.