### PR TITLE
Hotfix clustering

### DIFF
--- a/python/src/k_means.py
+++ b/python/src/k_means.py
@@ -11,6 +11,9 @@ from collections import defaultdict
 
 from create_folder_name import FolderNameCreator
 
+# Set random seed (I'm really not sure if this helps)
+np.random.seed(42)
+
 class KMeansCluster:
     def __init__(self, numClusters, max_depth, model, parent_folder):
         self.base_clusters = numClusters
@@ -205,7 +208,7 @@ class KMeansCluster:
             #    print("Continue")
                 continue
             try:
-                kmeans = KMeans(n_clusters=k, random_state=random_state, n_init="auto")
+                kmeans = KMeans(n_clusters=k, random_state=42, n_init="auto", init="k-means++", tol=1e-5)
                 labels = kmeans.fit_predict(X)
 
                 score = silhouette_score(X, labels)

--- a/python/src/k_means.py
+++ b/python/src/k_means.py
@@ -73,7 +73,7 @@ class KMeansCluster:
         if depth > 0:
             # Assign directory name
             folder_name = self.folder_namer.generateFolderName(files)        
-            dir_name = os.path.join(dir_prefix, folder_name)
+            dir_name = folder_name 
 
             if os.path.basename(dir_prefix) == folder_name:
                 return builder.buildDirectory(dir_prefix,files,[])

--- a/python/src/master.py
+++ b/python/src/master.py
@@ -73,7 +73,7 @@ class Master():
             print("Full vectors appended: " + str(self.full_vector_time_2 - self.start_time)) 
 
             # Recursively cluster and return a directory
-            kmeans = KMeansCluster(int(len(full_vecs) / 6 ), 10, self.full_vec.model, request.root.name)
+            kmeans = KMeansCluster(int(len(full_vecs) / 3 ), 10, self.full_vec.model, request.root.name)
             response_directory = kmeans.dirCluster(full_vecs,files)
             self.clustering_time = time.time()
             print("Clustering complete: " + str(self.clustering_time - self.start_time))

--- a/python/testing/test_clustering_request.py
+++ b/python/testing/test_clustering_request.py
@@ -11,21 +11,6 @@ from src import message_structure_pb2, message_structure_pb2_grpc
 from src.message_structure_pb2 import Directory, File, Tag, MetadataEntry, DirectoryRequest
 from src.request_handler import RequestHandler
 
-# Create a fixture to automatically setup and tear down a grpc_test_server
-@pytest.fixture(scope="module")
-def grpc_test_server():
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    message_structure_pb2_grpc.add_DirectoryServiceServicer_to_server(RequestHandler(), server)
-    port = server.add_insecure_port("localhost:0")  # OS assigns free port
-    server.start()
-
-    channel = grpc.insecure_channel(f"localhost:{port}")
-    stub = message_structure_pb2_grpc.DirectoryServiceStub(channel)
-
-    yield stub  # This is used in the test function
-
-    server.stop(None)
-
 
 
 # <------ INTEGRATION TESTING ----->


### PR DESCRIPTION
### Bug Fix: Clustering
- **Steps to Reproduce**:  N/A
- **Current Behaviour**: Clustering was not acting deterministically
- **Expected Behaviour**:  Clustering should produce same output consistently 
- **Cause**: random_state set to k instead of constant in recursive call
- **Solution**: Set random_state to 42 in recursive call. Also added numpy.random.seed(). Unsure if it makes a difference

### Bug Fix: Testing
- **Steps to Reproduce**: Running tests
- **Current Behaviour**: Error when running test grpc not defined
- **Expected Behaviour**:  Test should run and pass
- **Cause**: Redefined fixture without proper import.
- **Solution**: Used fixture from conftest. (This was my bad I should have told Dewald how to use the fixture)




