### PR TITLE
Hotfix clustering newpath

### DIFF
--- a/python/src/directory_builder.py
+++ b/python/src/directory_builder.py
@@ -5,26 +5,48 @@ from collections import defaultdict
 TEST_DIR = os.path.dirname(__file__)
 
 class DirectoryCreator:
-    # construct the map of map of list of file
+    """
+    Root = self.FILE_DIR (e.g. 'test_files_3').
+
+    Conventions:
+    - buildDirectory(rel_path, ...) takes a RELATIVE path under the root.
+      * rel_path == ""   -> the root directory node
+      * rel_path == "a"  -> child "a"
+      * rel_path == "a/b"-> grandchild "a/b"
+    - For compatibility with print, the root directory's
+      Directory.path is rendered as '<root>/<root>'.
+    - File.new_path is always '<root>/<full relative path>/<filename>'.
+      For the root level files: '<root>/<root>/<filename>'.
+    """
+
     def __init__(self, directoryName, fileMap):
-        self.directory_name_idx = 0 
-        self.directory_name = directoryName
-        #self.FILE_DIR = os.path.join(TEST_DIR, directoryName)
-        self.FILE_DIR = directoryName
+        self.directory_name_idx = 0
+        self.directory_name = directoryName   # display name of the root
+        self.FILE_DIR = directoryName         # root folder
         self.file_map = defaultdict()
         for file in fileMap:
             self.file_map[file["filename"]] = file
 
+    def get_path(self, rel_name: str) -> str:
 
-    def get_path(self, name):
-        return os.path.join(self.FILE_DIR, name)
+        return os.path.join(self.FILE_DIR, rel_name) if rel_name else self.FILE_DIR
 
+    def buildDirectory(self, rel_path: str, files, children):
+        """
+        rel_path: '' for root, otherwise 'a', 'a/b', ...
+        """
+        # Display name for the printing
+        display_name = self.directory_name if rel_path == "" else os.path.basename(rel_path)
 
-    def buildDirectory(self, name, files, children):
-        dir_path = self.get_path(name)
-        file_objs = [self.createFile(f["filename"], name) for f in files]
+        # Path formatting:
+        #  - Root dir path shows as '<root>/<root>' (matches your sample)
+        #  - Others: '<root>/<rel_path>'
+        dir_path = self.get_path(self.directory_name if rel_path == "" else rel_path)
+
+        file_objs = [self.createFile(f["filename"], rel_path) for f in files]
+
         return Directory(
-            name=name,
+            name=display_name,
             path=dir_path,
             files=file_objs,
             directories=children
@@ -36,7 +58,7 @@ class DirectoryCreator:
 
         merged_dir = Directory()
         merged_dir.name = dir1.name
-        merged_dir.path = self.get_path(dir1.name)
+        merged_dir.path = self.get_path(self.directory_name)  # keep root '<root>/<root>' style
 
         merged_dir.files.extend(list(dir1.files))
         merged_dir.files.extend(list(dir2.files))
@@ -46,36 +68,32 @@ class DirectoryCreator:
 
         return merged_dir
 
-
-
-    def createFile(self, filename, dirName):
+    def createFile(self, filename: str, rel_path: str):
+        """
+        rel_path is the relative directory path for this file.
+        """
         file_info = self.file_map[filename]
         original_file_path = file_info["absolute_path"]
-        new_file_path = self.get_path(f"{dirName}/{filename}")
         is_locked = file_info.get("is_locked", False)
 
-        my_tags = self.createTags(file_info)
+        # For root, new files appear under '<root>/<root>/<filename>'
+        # For others: '<root>/<rel_path>/<filename>'
+        path_base = self.directory_name if rel_path == "" else rel_path
+        new_file_path = self.get_path(os.path.join(path_base, filename))
+
         return File(
             name=filename,
             original_path=original_file_path,
             new_path=new_file_path,
-            tags=my_tags,  
+            tags=self.createTags(file_info),
             metadata=self.createMetaData(file_info),
-            is_locked = is_locked
-
+            is_locked=is_locked
         )
 
-
     def createTags(self, file_info):
-        if "tags" in file_info: 
-            tags = []
-            for tag in file_info["tags"]:
-               # print(tag)
-               tags.append(Tag(name=tag)) 
-            return tags
-        else:
-            return []
-
+        if "tags" in file_info:
+            return [Tag(name=tag) for tag in file_info["tags"]]
+        return []
 
     def createMetaData(self, file_info):
         return [
@@ -83,5 +101,3 @@ class DirectoryCreator:
             for key, val in file_info.items()
             if key not in ("keywords", "full_vector")
         ]
-    
-    


### PR DESCRIPTION
### Bug Fix - NewPath names
- **Steps to Reproduce**: Making a request to CLUSTERING had incorrect new_paths
- **Current Behaviour**: new_paths did not include entire directory prefix
- **Expected Behaviour**:  New path should include entire directory prefix from root of request.
- **Cause**: Relative paths were not being handled correctly
- **Solution**: Completely changed how DirectoryCreator works with relative paths. buildDirectory now takes rel_path.

### Feature - Better folder names & clustering
- **Summary**: New sub directories are not continuously made if new clusters result in too similar output (previously resulted in many subdirectories). Also adds counters to generic names or fall back to filetype based names. Also also added better print function
- **Usage**: CLUSTERING request
- **Input → Output**: 
```
[DIR] test_files_3 - test_files_3/test_files_3 [dirs=2 files=0]
├── [DIR] api - test_files_3/api [dirs=4 files=13]
│   ├── [DIR] images - test_files_3/api/images [dirs=0 files=20]
│   │   ├── [FILE] 3.6.4 Survey data to be analysed and visualised for project report mine.xlsx - test_files_3/api/images/3.6.4 Survey data to be analysed and visualised for project report mine.xlsx
│   │   ├── [FILE] architecture_diagram.png - test_files_3/api/images/architecture_diagram.png
│   │   ├── [FILE] collection_page_wireframe.png - test_files_3/api/images/collection_page_wireframe.png
│   │   ├── [FILE] DeeBee.png - test_files_3/api/images/DeeBee.png
│   │   ├── [FILE] Document[1].pdf - test_files_3/api/images/Document[1].pdf
│   │   ├── [FILE] ENjoyment.png - test_files_3/api/images/ENjoyment.png
│   │   ├── [FILE] Gantt chart.png - test_files_3/api/images/Gantt chart.png
│   │   ├── [FILE] Gauteng.png - test_files_3/api/images/Gauteng.png
│   │   ├── [FILE] login_wireframe.png - test_files_3/api/images/login_wireframe.png
│   │   ├── [FILE] Main.form - test_files_3/api/images/Main.form
│   │   ├── [FILE] most challanging.png - test_files_3/api/images/most challanging.png
│   │   ├── [FILE] Most rewarding.png - test_files_3/api/images/Most rewarding.png
│   │   ├── [FILE] mp11_requirement_spec.md - test_files_3/api/images/mp11_requirement_spec.md
│   │   ├── [FILE] Picture1.png - test_files_3/api/images/Picture1.png
│   │   ├── [FILE] Picture2.png - test_files_3/api/images/Picture2.png
│   │   ├── [FILE] Screenshot_2025-02-26_at_15.36.48.png - test_files_3/api/images/Screenshot_2025-02-26_at_15.36.48.png
│   │   ├── [FILE] statistics_page_wireframe.png - test_files_3/api/images/statistics_page_wireframe.png
│   │   ├── [FILE] Taiichi ohno.jpeg - test_files_3/api/images/Taiichi ohno.jpeg
│   │   ├── [FILE] UseCase.png - test_files_3/api/images/UseCase.png
│   │   └── [FILE] ~$ecutive summary.docx - test_files_3/api/images/~$ecutive summary.docx
│   ├── [DIR] probability - test_files_3/api/probability [dirs=0 files=4]
│   │   ├── [FILE] COS122 Tutorial 4 Sept 7-8, 2023.pdf - test_files_3/api/probability/COS122 Tutorial 4 Sept 7-8, 2023.pdf
│   │   ├── [FILE] Week 3_Tutorial_2024_with Answers.pdf - test_files_3/api/probability/Week 3_Tutorial_2024_with Answers.pdf
│   │   ├── [FILE] Week 4_Tutorial_with answers.pdf - test_files_3/api/probability/Week 4_Tutorial_with answers.pdf
│   │   └── [FILE] Week 5_Tutorial_2024_with answers.pdf - test_files_3/api/probability/Week 5_Tutorial_2024_with answers.pdf
│   ├── [DIR] project - test_files_3/api/project [dirs=0 files=4]
│   │   ├── [FILE] COS 301 - Mini-Project - Demo 1 Instructions.pdf - test_files_3/api/project/COS 301 - Mini-Project - Demo 1 Instructions.pdf
│   │   ├── [FILE] COS 301 - Mini-Project - Demo 2 Instructions.pdf - test_files_3/api/project/COS 301 - Mini-Project - Demo 2 Instructions.pdf
│   │   ├── [FILE] L05_Ch02c.pdf - test_files_3/api/project/L05_Ch02c.pdf
│   │   └── [FILE] Project Budget Form 2024.pdf - test_files_3/api/project/Project Budget Form 2024.pdf
│   ├── [DIR] project_statementthe_garage - test_files_3/api/project_statementthe_garage [dirs=0 files=2]
│   │   ├── [FILE] ~WRL0005.tmp - test_files_3/api/project_statementthe_garage/~WRL0005.tmp
│   │   └── [FILE] ~WRL1847.tmp - test_files_3/api/project_statementthe_garage/~WRL1847.tmp
│   ├── [FILE] Apr18 meeting.txt - test_files_3/api/Apr18 meeting.txt
│   ├── [FILE] Apr8TODO.txt - test_files_3/api/Apr8TODO.txt
│   ├── [FILE] COS221 Assignment 1 2025.pdf - test_files_3/api/COS221 Assignment 1 2025.pdf
│   ├── [FILE] cpp_api.md - test_files_3/api/cpp_api.md
│   ├── [FILE] Importing the Database.md - test_files_3/api/Importing the Database.md
│   ├── [FILE] Main.java - test_files_3/api/Main.java
│   ├── [FILE] MP Progress report.txt - test_files_3/api/MP Progress report.txt
│   ├── [FILE] mp11_design_specification.md - test_files_3/api/mp11_design_specification.md
│   ├── [FILE] MPChecklist.txt - test_files_3/api/MPChecklist.txt
│   ├── [FILE] Prac1Triggers.txt - test_files_3/api/Prac1Triggers.txt
│   ├── [FILE] Presentation speech.docx - test_files_3/api/Presentation speech.docx
│   ├── [FILE] TODO mar30 Meeting.txt - test_files_3/api/TODO mar30 Meeting.txt
│   └── [FILE] Tututorial_2.pdf - test_files_3/api/Tututorial_2.pdf
└── [DIR] cos122 - test_files_3/cos122 [dirs=0 files=2]
    ├── [FILE] Assignment2.pdf - test_files_3/cos122/Assignment2.pdf
    └── [FILE] L01_Ch01a(1).pdf - test_files_3/cos122/L01_Ch01a(1).pdf
```


