### PR TITLE
Python hotfix naming

### DIFF
--- a/python/src/create_folder_name.py
+++ b/python/src/create_folder_name.py
@@ -80,11 +80,16 @@ class FolderNameCreator:
         if not candidates:
             candidates = ["misc"]
 
+        # Lemmatize kws separately 
         words = self.lemmatize(candidates)
-        return self.format_case(words)
+
+        # Flatten list of lists into one word sequence
+        flat_words = [w for group in words for w in group]
+
+        return self.format_case(flat_words)
 
     def lemmatize(self, raw_keywords):
-        seen = set()
+        """Return list of lists: each keyword -> list of lemma words"""
         results = []
         for kw in raw_keywords:
             tokens = self._split_words(kw)
@@ -95,11 +100,9 @@ class FolderNameCreator:
                 lemma = self.lemmatizer.lemmatize(word, pos=wn_tag)
                 lemmas.append(lemma)
             if lemmas:
-                formatted = self.format_case(lemmas)
-                if formatted not in seen:
-                    seen.add(formatted)
-                    results.append(formatted)
-        return results or ["misc"]
+                results.append(lemmas)
+        return results or [["misc"]]
+
 
     def get_wordnet_pos(self, treebank_tag):
         if treebank_tag.startswith("J"):

--- a/python/src/master.py
+++ b/python/src/master.py
@@ -82,7 +82,7 @@ class Master():
             print("Full vectors appended: " + str(self.full_vector_time_2 - self.start_time)) 
 
             # Recursively cluster and return a directory
-            kmeans = KMeansCluster(int(len(full_vecs) / 3 ), 10, self.full_vec.model, request.root.name, request.prefferedCase)
+            kmeans = KMeansCluster(int(len(full_vecs) / 3 ), 10, self.full_vec.model, request.root.name, request.preferredCase)
             response_directory = kmeans.dirCluster(full_vecs,files)
             self.clustering_time = time.time()
             print("Clustering complete: " + str(self.clustering_time - self.start_time))

--- a/python/testing/test_clustering_request.py
+++ b/python/testing/test_clustering_request.py
@@ -102,7 +102,7 @@ def createDirectoryRequest():
         files = files1
     )    
 
-    req = DirectoryRequest(root=root_dir, requestType="CLUSTERING", serverSecret=os.environ["SFM_SERVER_SECRET"], prefferedCase = "CAMEL")
+    req = DirectoryRequest(root=root_dir, requestType="CLUSTERING", serverSecret=os.environ["SFM_SERVER_SECRET"], preferredCase = "KEBAB")
     yield req
 
 


### PR DESCRIPTION
### Bug Fix

Small fixes and changes

* Fixed some small things that broke (missing imports and I merged the wrong thing...)
* Changed DirectoryRequest attribute to preferredCase (fixing the spelling mistake) and updated the code to use that one
* Fixed the folder naming since it was applying the case convention after the keywords were combined into a folder name. So instead of having ```Blackpearl``` it correctly generates ```BlackPearl```.
